### PR TITLE
uploader: add blob exporting (#3410)

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -15,6 +15,7 @@ py_library(
 py_library(
     name = "exporter_lib",
     srcs = ["exporter.py"],
+    srcs_version = "PY3",
     deps = [
         ":util",
         "//tensorboard:expect_grpc_installed",

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import base64
+import contextlib
 import errno
 import grpc
 import json
@@ -28,6 +29,7 @@ import time
 
 import six
 
+from tensorboard.uploader.proto import blob_pb2
 from tensorboard.uploader.proto import experiment_pb2
 from tensorboard.uploader.proto import export_service_pb2
 from tensorboard.uploader import util
@@ -50,6 +52,15 @@ _MAX_INT64 = 2 ** 63 - 1
 _FILENAME_METADATA = "metadata.json"
 # Output filename for scalar data within an experiment directory.
 _FILENAME_SCALARS = "scalars.json"
+# Output filename for blob sequences data within an experiment directory.
+# This file does not contain the actual contents of the blobs. Instead,
+# it holds `blob_file_path`s that point to the binary files that contain
+# the blobs' contents, in addition to other metadata such as run and tag names.
+_FILENAME_BLOB_SEQUENCES = "blob_sequences.json"
+
+_DIRNAME_BLOBS = "blobs"
+_FILENAME_BLOBS_PREFIX = "blob_"
+_FILENAME_BLOBS_SUFFIX = ".bin"
 
 logger = tb_logging.get_logger()
 
@@ -147,23 +158,51 @@ class TensorBoardExporter(object):
                 json.dump(experiment_metadata, outfile, sort_keys=True)
                 outfile.write("\n")
 
-            scalars_filepath = os.path.join(experiment_dir, _FILENAME_SCALARS)
             try:
-                with _open_excl(scalars_filepath) as outfile:
-                    data = self._request_scalar_data(experiment_id, read_time)
-                    for block in data:
+                data = self._request_json_data(experiment_id, read_time)
+                with contextlib.ExitStack() as stack:
+                    file_handles = {
+                        filename: stack.enter_context(
+                            _open_excl(os.path.join(experiment_dir, filename))
+                        )
+                        for filename in (
+                            _FILENAME_SCALARS,
+                            _FILENAME_BLOB_SEQUENCES,
+                        )
+                    }
+                    os.mkdir(os.path.join(experiment_dir, _DIRNAME_BLOBS))
+                    for block, filename in data:
+                        outfile = file_handles[filename]
                         json.dump(block, outfile, sort_keys=True)
                         outfile.write("\n")
                         outfile.flush()
-                yield experiment_id
+                    yield experiment_id
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.CANCELLED:
                     raise GrpcTimeoutException(experiment_id)
                 else:
                     raise
 
-    def _request_scalar_data(self, experiment_id, read_time):
-        """Yields JSON-serializable blocks of scalar data."""
+    def _request_json_data(self, experiment_id, read_time):
+        """Given experiment id, generates JSON data and destination file name.
+
+        The JSON data describes the run, tag, metadata, in addition to
+          - Actual data in the case of scalars
+          - Pointer to binary files in the case of blob sequences.
+
+        For the case of blob sequences, this method has the side effect of
+          downloading the contents of the blobs and writing them to files in
+          a subdirectory of the experiment directory.
+
+        Args:
+          experiment_id: The id of the experiment to request data for.
+          read_time: A fixed timestamp from which to export data, as float
+            seconds since epoch (like `time.time()`). Optional; defaults to the
+            current time.
+
+        Yields:
+          (JSON-serializable data, destination file name) tuples.
+        """
         request = export_service_pb2.StreamExperimentDataRequest()
         request.experiment_id = experiment_id
         util.set_timestamp(request.read_timestamp, read_time)
@@ -180,19 +219,126 @@ class TensorBoardExporter(object):
             metadata = base64.b64encode(
                 response.tag_metadata.SerializeToString()
             ).decode("ascii")
-            wall_times = [
-                t.ToNanoseconds() / 1e9 for t in response.points.wall_times
-            ]
-            yield {
+            json_data = {
                 u"run": response.run_name,
                 u"tag": response.tag_name,
                 u"summary_metadata": metadata,
-                u"points": {
-                    u"steps": list(response.points.steps),
-                    u"wall_times": wall_times,
-                    u"values": list(response.points.values),
-                },
             }
+            filename = None
+            if response.HasField("points"):
+                json_data[u"points"] = self._process_scalar_points(
+                    response.points
+                )
+                filename = _FILENAME_SCALARS
+            elif response.HasField("blob_sequences"):
+                json_data[u"points"] = self._process_blob_sequence_points(
+                    response.blob_sequences, experiment_id
+                )
+                filename = _FILENAME_BLOB_SEQUENCES
+            if filename:
+                yield json_data, filename
+            else:
+                logger.warning(
+                    "Skipping a response from experiment-data stream "
+                    "due to the lack of any valid data type (such as "
+                    "scalars and blob sequences): run=%s, tag=%s. "
+                    "Updating tensorboard install may fix this warning."
+                    % (response.run_name, response.tag_name)
+                )
+
+    def _process_scalar_points(self, points):
+        """Process scalar data points.
+
+        Args:
+          points: `export_service_pb2.StreamExperimentDataResponse.ScalarPoints`
+            proto.
+
+        Returns:
+          A JSON-serializable `dict` for the steps, wall_times and values of the
+            scalar data points.
+        """
+        wall_times = [t.ToNanoseconds() / 1e9 for t in points.wall_times]
+        return {
+            u"steps": list(points.steps),
+            u"wall_times": wall_times,
+            u"values": list(points.values),
+        }
+
+    def _process_blob_sequence_points(self, blob_sequences, experiment_id):
+        """Process blob sequence points.
+
+        As a side effect, also downloads the binary contents of the blobs
+        to respective files. The paths to the files relative to the
+        experiment directory is encapsulated in the returned JSON object.
+
+        Args:
+          blob_sequences:
+            `export_service_pb2.StreamDataResponse.BlobSequencePoints` proto.
+
+        Returns:
+          A JSON-serializable `dict` for the steps and wall_times, as well as
+            the blob_file_paths, which are the relative paths to the downloaded
+            blob contents.
+        """
+        wall_times = [
+            t.ToNanoseconds() / 1e9 for t in blob_sequences.wall_times
+        ]
+        json_object = {
+            u"steps": list(blob_sequences.steps),
+            u"wall_times": wall_times,
+            u"blob_file_paths": [],
+        }
+        blob_file_paths = json_object[u"blob_file_paths"]
+        for blobseq in blob_sequences.values:
+            seq_blob_file_paths = []
+            for entry in blobseq.entries:
+                if entry.blob.state == blob_pb2.BlobState.BLOB_STATE_CURRENT:
+                    blob_path = self._download_blob(
+                        entry.blob.blob_id, experiment_id
+                    )
+                    seq_blob_file_paths.append(blob_path)
+                else:
+                    seq_blob_file_paths.append(None)
+            blob_file_paths.append(seq_blob_file_paths)
+        return json_object
+
+    def _download_blob(self, blob_id, experiment_id):
+        """Download the blob via rpc.
+
+        Args:
+          blob_id: Id of the blob.
+          experiment_id: Id of the experiment that the blob belongs to.
+
+        Returns:
+          If the blob is downloaded successfully:
+            The path of the downloaded blob file relative to the experiment
+            directory.
+          Else:
+            `None`.
+        """
+        # TODO(cais): Deduplicate with internal method perhaps.
+        experiment_dir = _experiment_directory(self._outdir, experiment_id)
+        request = export_service_pb2.StreamBlobDataRequest(blob_id=blob_id)
+        blob_abspath = os.path.join(
+            experiment_dir,
+            _DIRNAME_BLOBS,
+            _FILENAME_BLOBS_PREFIX + blob_id + _FILENAME_BLOBS_SUFFIX,
+        )
+        with _open_excl(blob_abspath, "wb") as f:
+            try:
+                for response in self._api.StreamBlobData(
+                    request, metadata=grpc_util.version_metadata()
+                ):
+                    # TODO(cais, soergel): validate the various response fields
+                    f.write(response.data)
+            except grpc.RpcError as rpc_error:
+                logger.error(
+                    "Omitting blob (id: %s) due to download failure: %s",
+                    blob_id,
+                    rpc_error,
+                )
+                return None
+        return os.path.relpath(blob_abspath, experiment_dir)
 
 
 def list_experiments(api_client, fieldmask=None, read_time=None):
@@ -276,8 +422,8 @@ def _mkdir_p(path):
             raise
 
 
-def _open_excl(path):
-    """Like `open(path, "x")`, but Python 2-compatible."""
+def _open_excl(path, mode="w"):
+    """Like `open(path, mode.replace("w", "x"))`, but Python 2-compatible."""
     try:
         # `os.O_EXCL` works on Windows as well as POSIX-compliant systems.
         # See: <https://bugs.python.org/issue12760>
@@ -287,4 +433,4 @@ def _open_excl(path):
             raise OutputFileExistsError(path)
         else:
             raise
-    return os.fdopen(fd, "w")
+    return os.fdopen(fd, mode)

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -33,6 +33,7 @@ except ImportError:
     import mock  # pylint: disable=unused-import
 
 
+from tensorboard.uploader.proto import blob_pb2
 from tensorboard.uploader.proto import experiment_pb2
 from tensorboard.uploader.proto import export_service_pb2
 from tensorboard.uploader.proto import export_service_pb2_grpc
@@ -52,11 +53,21 @@ def _make_experiments_response(eids):
     return response
 
 
+def _outdir_files(outdir):
+    """Recursively list `outdir`."""
+    result = []
+    for (dirpath, dirnames, filenames) in os.walk(outdir):
+        for filename in filenames:
+            fullpath = os.path.join(dirpath, filename)
+            result.append(os.path.relpath(fullpath, outdir))
+    return result
+
+
 class TensorBoardExporterTest(tb_test.TestCase):
     def _create_mock_api_client(self):
         return _create_mock_api_client()
 
-    def test_e2e_success_case(self):
+    def test_e2e_success_case_with_only_scalar_data(self):
         mock_api_client = self._create_mock_api_client()
         mock_api_client.StreamExperiments.return_value = iter(
             [_make_experiments_response(["789"])]
@@ -109,19 +120,10 @@ class TensorBoardExporterTest(tb_test.TestCase):
         start_time = 1571084846.25
         start_time_pb = test_util.timestamp_pb(1571084846250000000)
 
-        def outdir_files():
-            # Recursively list `outdir`.
-            result = []
-            for (dirpath, dirnames, filenames) in os.walk(outdir):
-                for filename in filenames:
-                    fullpath = os.path.join(dirpath, filename)
-                    result.append(os.path.relpath(fullpath, outdir))
-            return result
-
         generator = exporter.export(read_time=start_time)
         expected_files = []
         self.assertTrue(os.path.isdir(outdir))
-        self.assertCountEqual(expected_files, outdir_files())
+        self.assertCountEqual(expected_files, _outdir_files(outdir))
         mock_api_client.StreamExperiments.assert_not_called()
         mock_api_client.StreamExperimentData.assert_not_called()
 
@@ -130,7 +132,11 @@ class TensorBoardExporterTest(tb_test.TestCase):
         self.assertEqual(next(generator), "123")
         expected_files.append(os.path.join("experiment_123", "metadata.json"))
         expected_files.append(os.path.join("experiment_123", "scalars.json"))
-        self.assertCountEqual(expected_files, outdir_files())
+        # blob_sequences.json should exist and be empty.
+        expected_files.append(
+            os.path.join("experiment_123", "blob_sequences.json")
+        )
+        self.assertCountEqual(expected_files, _outdir_files(outdir))
 
         expected_eids_request = export_service_pb2.StreamExperimentsRequest()
         expected_eids_request.read_timestamp.CopyFrom(start_time_pb)
@@ -157,7 +163,11 @@ class TensorBoardExporterTest(tb_test.TestCase):
 
         expected_files.append(os.path.join("experiment_456", "metadata.json"))
         expected_files.append(os.path.join("experiment_456", "scalars.json"))
-        self.assertCountEqual(expected_files, outdir_files())
+        # blob_sequences.json should exist and be empty.
+        expected_files.append(
+            os.path.join("experiment_456", "blob_sequences.json")
+        )
+        self.assertCountEqual(expected_files, _outdir_files(outdir))
         mock_api_client.StreamExperiments.assert_not_called()
         expected_data_request.experiment_id = "456"
         mock_api_client.StreamExperimentData.assert_called_once_with(
@@ -168,11 +178,15 @@ class TensorBoardExporterTest(tb_test.TestCase):
         # was in the second response batch in the list of IDs.
         expected_files.append(os.path.join("experiment_789", "metadata.json"))
         expected_files.append(os.path.join("experiment_789", "scalars.json"))
+        # blob_sequences.json should exist and be empty.
+        expected_files.append(
+            os.path.join("experiment_789", "blob_sequences.json")
+        )
         mock_api_client.StreamExperiments.reset_mock()
         mock_api_client.StreamExperimentData.reset_mock()
         self.assertEqual(next(generator), "789")
 
-        self.assertCountEqual(expected_files, outdir_files())
+        self.assertCountEqual(expected_files, _outdir_files(outdir))
         mock_api_client.StreamExperiments.assert_not_called()
         expected_data_request.experiment_id = "789"
         mock_api_client.StreamExperimentData.assert_called_once_with(
@@ -184,7 +198,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
         mock_api_client.StreamExperimentData.reset_mock()
         self.assertEqual(list(generator), [])
 
-        self.assertCountEqual(expected_files, outdir_files())
+        self.assertCountEqual(expected_files, _outdir_files(outdir))
         mock_api_client.StreamExperiments.assert_not_called()
         mock_api_client.StreamExperimentData.assert_not_called()
 
@@ -212,6 +226,13 @@ class TensorBoardExporterTest(tb_test.TestCase):
         self.assertEqual(points, {})
         self.assertEqual(datum, {})
 
+        # Check that one of the blob_sequences data file is empty, because there
+        # no blob sequences in this experiment.
+        with open(
+            os.path.join(outdir, "experiment_456", "blob_sequences.json")
+        ) as infile:
+            self.assertEqual(infile.read(), "")
+
         # Spot-check one of the metadata files.
         with open(
             os.path.join(outdir, "experiment_789", "metadata.json")
@@ -226,6 +247,222 @@ class TensorBoardExporterTest(tb_test.TestCase):
                 "update_time": "2002-03-04T05:06:07Z",
             },
         )
+
+    def test_e2e_success_case_with_blob_sequence_data(self):
+        """Covers exporting of complete and incomplete blob sequences
+
+        as well as rpc error during blob streaming.
+        """
+        mock_api_client = self._create_mock_api_client()
+
+        def stream_experiments(request, **kwargs):
+            del request  # unused
+            self.assertEqual(kwargs["metadata"], grpc_util.version_metadata())
+
+            response = export_service_pb2.StreamExperimentsResponse()
+            response.experiments.add(experiment_id="123")
+            yield response
+            response = export_service_pb2.StreamExperimentsResponse()
+            response.experiments.add(experiment_id="456")
+            yield response
+
+        def stream_experiment_data(request, **kwargs):
+            self.assertEqual(kwargs["metadata"], grpc_util.version_metadata())
+
+            tag = "__default_graph__"
+            for run in ("train", "test"):
+                response = export_service_pb2.StreamExperimentDataResponse()
+                response.run_name = run
+                response.tag_name = tag
+                display_name = "%s:%s" % (request.experiment_id, tag)
+                response.tag_metadata.CopyFrom(
+                    summary_pb2.SummaryMetadata(
+                        data_class=summary_pb2.DATA_CLASS_BLOB_SEQUENCE
+                    )
+                )
+                for step in range(1):
+                    response.blob_sequences.steps.append(step)
+                    response.blob_sequences.wall_times.add(
+                        seconds=1571084520 + step, nanos=862939144
+                    )
+                    blob_sequence = blob_pb2.BlobSequence()
+                    if run == "train":
+                        # A finished blob sequence.
+                        blob = blob_pb2.Blob(
+                            blob_id="%s_blob" % run,
+                            state=blob_pb2.BlobState.BLOB_STATE_CURRENT,
+                        )
+                        blob_sequence.entries.append(
+                            blob_pb2.BlobSequenceEntry(blob=blob)
+                        )
+                        # An unfinished blob sequence.
+                        blob = blob_pb2.Blob(
+                            state=blob_pb2.BlobState.BLOB_STATE_UNFINALIZED,
+                        )
+                        blob_sequence.entries.append(
+                            blob_pb2.BlobSequenceEntry(blob=blob)
+                        )
+                    elif run == "test":
+                        blob_sequence.entries.append(
+                            # `blob` unspecified: a hole in the blob sequence.
+                            blob_pb2.BlobSequenceEntry()
+                        )
+                    response.blob_sequences.values.append(blob_sequence)
+                yield response
+
+        mock_api_client.StreamExperiments = mock.Mock(wraps=stream_experiments)
+        mock_api_client.StreamExperimentData = mock.Mock(
+            wraps=stream_experiment_data
+        )
+        mock_api_client.StreamBlobData.side_effect = [
+            iter(
+                [
+                    export_service_pb2.StreamBlobDataResponse(
+                        data=b"4321", offset=0, final_chunk=False,
+                    ),
+                    export_service_pb2.StreamBlobDataResponse(
+                        data=b"8765", offset=4, final_chunk=True,
+                    ),
+                ]
+            ),
+            # Raise error from `StreamBlobData` to test the grpc-error
+            # condition.
+            test_util.grpc_error(grpc.StatusCode.INTERNAL, "Error for testing"),
+        ]
+
+        outdir = os.path.join(self.get_temp_dir(), "outdir")
+        exporter = exporter_lib.TensorBoardExporter(mock_api_client, outdir)
+        start_time = 1571084846.25
+        start_time_pb = test_util.timestamp_pb(1571084846250000000)
+
+        generator = exporter.export(read_time=start_time)
+        expected_files = []
+        self.assertTrue(os.path.isdir(outdir))
+        self.assertCountEqual(expected_files, _outdir_files(outdir))
+        mock_api_client.StreamExperiments.assert_not_called()
+        mock_api_client.StreamExperimentData.assert_not_called()
+
+        # The first iteration should request the list of experiments and
+        # data for one of them.
+        self.assertEqual(next(generator), "123")
+        expected_files.append(os.path.join("experiment_123", "metadata.json"))
+        # scalars.json should exist and be empty.
+        expected_files.append(os.path.join("experiment_123", "scalars.json"))
+        expected_files.append(
+            os.path.join("experiment_123", "blob_sequences.json")
+        )
+        expected_files.append(
+            os.path.join("experiment_123", "blobs", "blob_train_blob.bin")
+        )
+        # blobs/blob_test_blob.bin should not exist, because it contains
+        # an unfinished blob.
+        self.assertCountEqual(expected_files, _outdir_files(outdir))
+
+        # Check that the scalars data file is empty, because there no scalars.
+        with open(
+            os.path.join(outdir, "experiment_123", "scalars.json")
+        ) as infile:
+            self.assertEqual(infile.read(), "")
+
+        # Check the blob_sequences.json file.
+        with open(
+            os.path.join(outdir, "experiment_123", "blob_sequences.json")
+        ) as infile:
+            jsons = [json.loads(line) for line in infile]
+        self.assertLen(jsons, 2)
+
+        datum = jsons[0]
+        self.assertEqual(datum.pop("run"), "train")
+        self.assertEqual(datum.pop("tag"), "__default_graph__")
+        summary_metadata = summary_pb2.SummaryMetadata.FromString(
+            base64.b64decode(datum.pop("summary_metadata"))
+        )
+        expected_summary_metadata = summary_pb2.SummaryMetadata(
+            data_class=summary_pb2.DATA_CLASS_BLOB_SEQUENCE
+        )
+        self.assertEqual(summary_metadata, expected_summary_metadata)
+        points = datum.pop("points")
+        self.assertEqual(datum, {})
+        self.assertEqual(points.pop("steps"), [0])
+        self.assertEqual(points.pop("wall_times"), [1571084520.862939144])
+        # The 1st blob is finished; the 2nd is unfinished.
+        self.assertEqual(
+            points.pop("blob_file_paths"), [["blobs/blob_train_blob.bin", None]]
+        )
+        self.assertEqual(points, {})
+
+        datum = jsons[1]
+        self.assertEqual(datum.pop("run"), "test")
+        self.assertEqual(datum.pop("tag"), "__default_graph__")
+        summary_metadata = summary_pb2.SummaryMetadata.FromString(
+            base64.b64decode(datum.pop("summary_metadata"))
+        )
+        self.assertEqual(summary_metadata, expected_summary_metadata)
+        points = datum.pop("points")
+        self.assertEqual(datum, {})
+        self.assertEqual(points.pop("steps"), [0])
+        self.assertEqual(points.pop("wall_times"), [1571084520.862939144])
+        # `None` blob file path indicates an unfinished blob.
+        self.assertEqual(points.pop("blob_file_paths"), [[None]])
+        self.assertEqual(points, {})
+
+        # Check the BLOB files.
+        with open(
+            os.path.join(
+                outdir, "experiment_123", "blobs", "blob_train_blob.bin"
+            ),
+            "rb",
+        ) as f:
+            self.assertEqual(f.read(), b"43218765")
+
+        # Check call to StreamBlobData.
+        expected_blob_data_request = export_service_pb2.StreamBlobDataRequest(
+            blob_id="train_blob"
+        )
+        mock_api_client.StreamBlobData.assert_called_once_with(
+            expected_blob_data_request, metadata=grpc_util.version_metadata()
+        )
+
+        # Test the case where blob streaming errors out.
+        self.assertEqual(next(generator), "456")
+        # Check the blob_sequences.json file.
+        with open(
+            os.path.join(outdir, "experiment_456", "blob_sequences.json")
+        ) as infile:
+            jsons = [json.loads(line) for line in infile]
+        self.assertLen(jsons, 2)
+
+        datum = jsons[0]
+        self.assertEqual(datum.pop("run"), "train")
+        self.assertEqual(datum.pop("tag"), "__default_graph__")
+        summary_metadata = summary_pb2.SummaryMetadata.FromString(
+            base64.b64decode(datum.pop("summary_metadata"))
+        )
+        self.assertEqual(summary_metadata, expected_summary_metadata)
+        points = datum.pop("points")
+        self.assertEqual(datum, {})
+        self.assertEqual(points.pop("steps"), [0])
+        self.assertEqual(points.pop("wall_times"), [1571084520.862939144])
+        # `None` represents the blob that experienced error during downloading
+        # and hence is missing.
+        self.assertEqual(points.pop("blob_file_paths"), [[None, None]])
+        self.assertEqual(points, {})
+
+        datum = jsons[1]
+        self.assertEqual(datum.pop("run"), "test")
+        self.assertEqual(datum.pop("tag"), "__default_graph__")
+        summary_metadata = summary_pb2.SummaryMetadata.FromString(
+            base64.b64decode(datum.pop("summary_metadata"))
+        )
+        self.assertEqual(summary_metadata, expected_summary_metadata)
+        points = datum.pop("points")
+        self.assertEqual(datum, {})
+        self.assertEqual(points.pop("steps"), [0])
+        self.assertEqual(points.pop("wall_times"), [1571084520.862939144])
+        # `None` represents the blob that experienced error during downloading
+        # and hence is missing.
+        self.assertEqual(points.pop("blob_file_paths"), [[None]])
+        self.assertEqual(points, {})
 
     def test_rejects_dangerous_experiment_ids(self):
         mock_api_client = self._create_mock_api_client()


### PR DESCRIPTION
* Motivation for features / changes
  * Support exporting of blob data from tensorboard.dev uploader
* Technical description of changes
  * In exporter.py, branch the handling logic for `StreamExperimentDataResponse` protos
    depending on whether
    * `points` is available (for scalars), or
    * `blob_sequences` is available (for blob sequences)
  * For the blob sequences, add method to download the blob via rpc in chunks.
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added, see exporter_test.py
  * Manual testing against a locally running backend (cross reference with CL/301719321)

* Motivation for features / changes

* Technical description of changes

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
